### PR TITLE
Added missing models to client module

### DIFF
--- a/client/src/main/scala/sbtcompendium/client/CompendiumClient.scala
+++ b/client/src/main/scala/sbtcompendium/client/CompendiumClient.scala
@@ -23,7 +23,7 @@ import cats.free.Free
 import cats.implicits._
 import hammock._
 import hammock.circe.implicits._
-import higherkindness.compendium.models._
+import sbtcompendium.models._
 import scala.util.Try
 
 trait CompendiumClient[F[_]] {

--- a/client/src/main/scala/sbtcompendium/models/ErrorResponse.scala
+++ b/client/src/main/scala/sbtcompendium/models/ErrorResponse.scala
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-package sbtcompendium.client
+package sbtcompendium.models
 
-import sbtcompendium.models.config.HttpConfig
+import io.circe._
+import io.circe.generic.semiauto._
 
-final case class CompendiumClientConfig(http: HttpConfig)
+final case class ErrorResponse(message: String)
+
+object ErrorResponse {
+  implicit val decoder: Decoder[ErrorResponse] = deriveDecoder[ErrorResponse]
+  implicit val encoder: Encoder[ErrorResponse] = deriveEncoder[ErrorResponse]
+}

--- a/client/src/main/scala/sbtcompendium/models/IdlName.scala
+++ b/client/src/main/scala/sbtcompendium/models/IdlName.scala
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-package sbtcompendium.client
+package sbtcompendium.models
 
-import sbtcompendium.models.config.HttpConfig
+import enumeratum.EnumEntry.Lowercase
+import enumeratum._
 
-final case class CompendiumClientConfig(http: HttpConfig)
+sealed trait IdlName extends EnumEntry
+
+object IdlName extends Enum[IdlName] with CirceEnum[IdlName] {
+  val values = findValues
+
+  case object Avro     extends IdlName with Lowercase
+  case object Protobuf extends IdlName with Lowercase
+  case object Mu       extends IdlName with Lowercase
+  case object OpenApi  extends IdlName with Lowercase
+  case object Scala    extends IdlName with Lowercase
+}

--- a/client/src/main/scala/sbtcompendium/models/Protocol.scala
+++ b/client/src/main/scala/sbtcompendium/models/Protocol.scala
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-package sbtcompendium.client
+package sbtcompendium.models
 
-import sbtcompendium.models.config.HttpConfig
+import io.circe._
+import io.circe.generic.semiauto._
 
-final case class CompendiumClientConfig(http: HttpConfig)
+final case class Protocol(raw: String)
+
+object Protocol {
+  implicit val decoder: Decoder[Protocol] = deriveDecoder[Protocol]
+  implicit val encoder: Encoder[Protocol] = deriveEncoder[Protocol]
+}

--- a/client/src/main/scala/sbtcompendium/models/config/HttpConfig.scala
+++ b/client/src/main/scala/sbtcompendium/models/config/HttpConfig.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-package sbtcompendium.client
+package sbtcompendium.models.config
 
-import sbtcompendium.models.config.HttpConfig
-
-final case class CompendiumClientConfig(http: HttpConfig)
+final case class HttpConfig(host: String, port: Int)

--- a/client/src/main/scala/sbtcompendium/models/errors.scala
+++ b/client/src/main/scala/sbtcompendium/models/errors.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtcompendium.models
+
+abstract class CompendiumError(error: String) extends Exception(error)
+
+final case class FileNotFound(fileName: String)    extends CompendiumError(s"File with name $fileName not found")
+final case class ProtocolIdError(msg: String)      extends CompendiumError(msg)
+final case class ProtocolVersionError(msg: String) extends CompendiumError(msg)
+final case class ProtocolNotFound(msg: String)     extends CompendiumError(msg)
+final case class UnknownIdlName(msg: String)       extends CompendiumError(msg)
+final case class SchemaError(msg: String)          extends CompendiumError(msg)
+final case class UnknownError(msg: String)         extends CompendiumError(msg)

--- a/client/src/test/scala/sbtcompendium/client/CompendiumClientSpec.scala
+++ b/client/src/test/scala/sbtcompendium/client/CompendiumClientSpec.scala
@@ -19,7 +19,7 @@ package sbtcompendium.client
 import cats.effect.{IO, Sync}
 import cats.~>
 import hammock.{HttpF, HttpRequest, InterpTrans, Post}
-import higherkindness.compendium.models._
+import sbtcompendium.models._
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import pureconfig.generic.auto._
@@ -129,7 +129,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
 
       CompendiumClient[IO]()
         .retrieveProtocol("error", None)
-        .unsafeRunSync() must throwA[higherkindness.compendium.models.UnknownError]
+        .unsafeRunSync() must throwA[sbtcompendium.models.UnknownError]
     }
   }
 
@@ -147,7 +147,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
 
       CompendiumClient[IO]()
         .storeProtocol("schemaerror", dummyProtocol)
-        .unsafeRunSync() must throwA[higherkindness.compendium.models.SchemaError]
+        .unsafeRunSync() must throwA[sbtcompendium.models.SchemaError]
     }
 
     "Given a valid identifier and a protocol that already exists returns no error" >> {
@@ -165,7 +165,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
 
       CompendiumClient[IO]()
         .storeProtocol("internal", dummyProtocol)
-        .unsafeRunSync() must throwA[higherkindness.compendium.models.UnknownError]
+        .unsafeRunSync() must throwA[sbtcompendium.models.UnknownError]
     }
   }
 

--- a/client/src/test/scala/sbtcompendium/client/CompendiumClientSpec.scala
+++ b/client/src/test/scala/sbtcompendium/client/CompendiumClientSpec.scala
@@ -36,7 +36,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
   implicit val clientConfig: CompendiumClientConfig =
     pureconfig.ConfigSource.default.at("compendium").loadOrThrow[CompendiumClientConfig]
 
-  def interp[F[_] : Sync](identifier: String, target: IdlName, version: Option[Int] = None): InterpTrans[F] =
+  def interp[F[_]: Sync](identifier: String, target: IdlName, version: Option[Int] = None): InterpTrans[F] =
     new InterpTrans[F] {
 
       val trans: HttpF ~> F = new (HttpF ~> F) {
@@ -50,7 +50,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
             }
 
           case Get(HttpRequest(uri, _, _))
-            if uri.path.equalsIgnoreCase(s"/v0/protocol/$identifier?version=${version.getOrElse(0)}") =>
+              if uri.path.equalsIgnoreCase(s"/v0/protocol/$identifier?version=${version.getOrElse(0)}") =>
             F.catchNonFatal {
               response(asEntityJson(dummyProtocol))
             }
@@ -61,7 +61,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
             }
 
           case Get(HttpRequest(uri, _, _))
-            if uri.path.equalsIgnoreCase(s"/v0/protocol/$identifier/generate?target=${target.toString}") =>
+              if uri.path.equalsIgnoreCase(s"/v0/protocol/$identifier/generate?target=${target.toString}") =>
             F.catchNonFatal {
               response(Entity.StringEntity(uri.path)).copy(status = Status.NotImplemented)
             }
@@ -172,7 +172,7 @@ object CompendiumClientSpec extends Specification with ScalaCheck {
   "Generate client" >> {
     "Given a valid identifier and a valid target" >> {
       failure
-      }.pendingUntilFixed
+    }.pendingUntilFixed
   }
 
 }

--- a/plugin/src/main/scala/sbtcompendium/CompendiumPlugin.scala
+++ b/plugin/src/main/scala/sbtcompendium/CompendiumPlugin.scala
@@ -19,8 +19,8 @@ package sbtcompendium
 import cats.effect.IO
 import cats.implicits._
 import hammock.asynchttpclient.AsyncHttpClientInterpreter
-import higherkindness.compendium.models._
-import higherkindness.compendium.models.config.HttpConfig
+import sbtcompendium.models._
+import sbtcompendium.models.config.HttpConfig
 import sbt._
 import sbtcompendium.client.{CompendiumClient, CompendiumClientConfig}
 

--- a/plugin/src/main/scala/sbtcompendium/CompendiumUtils.scala
+++ b/plugin/src/main/scala/sbtcompendium/CompendiumUtils.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import cats.syntax.either._
 import cats.effect.IO
-import higherkindness.compendium.models._
+import sbtcompendium.models._
 
 object CompendiumUtils {
 

--- a/plugin/src/sbt-test/sbtcompendium/basic/build.sbt
+++ b/plugin/src/sbt-test/sbtcompendium/basic/build.sbt
@@ -1,7 +1,6 @@
 import cats.effect.IO
 import cats.implicits._
 import sbtcompendium.models.IdlName
-//import sbtcompendium.CompendiumUtils
 import sbtcompendium._
 
 scalaVersion := "2.12.10"

--- a/plugin/src/sbt-test/sbtcompendium/basic/build.sbt
+++ b/plugin/src/sbt-test/sbtcompendium/basic/build.sbt
@@ -1,6 +1,6 @@
 import cats.effect.IO
 import cats.implicits._
-import higherkindness.compendium.models.IdlName
+import sbtcompendium.models.IdlName
 //import sbtcompendium.CompendiumUtils
 import sbtcompendium._
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -21,27 +21,29 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     val V = new {
-      val cats           = "2.1.0"
-      val compendium     = "0.0.1-SNAPSHOT"
+      val cats = "2.1.0"
       val contextApplied = "0.1.2"
-      val enumeratum     = "1.5.15"
-      val hammock        = "0.10.0"
-      val kindProjector  = "0.11.0"
-      val scala          = "2.12.10"
-      val specs2         = "4.8.3"
-      val avroHugger     = "1.0.0-RC22"
+      val enumeratum = "1.5.15"
+      val hammock = "0.10.0"
+      val kindProjector = "0.11.0"
+      val scala = "2.12.10"
+      val specs2 = "4.8.3"
+      val avroHugger = "1.0.0-RC22"
+      val pureconfig = "0.12.2"
     }
 
     val clientSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("cats-core", V.cats),
-        "io.higherkindness"               %% "compendium-common" % V.compendium,
-        "com.pepegar"                     %% "hammock-core" % V.hammock,
-        "com.pepegar"                     %% "hammock-circe" % V.hammock,
-        "com.pepegar"                     %% "hammock-asynchttpclient" % V.hammock,
-        "com.beachape"                    %% "enumeratum" % V.enumeratum,
-        "com.julianpeeters"               %% "avrohugger-core" % V.avroHugger,
-        %%("specs2-core", V.specs2)       % Test,
+        %%("pureconfig", V.pureconfig),
+        "com.github.pureconfig" %% "pureconfig-cats-effect" % V.pureconfig,
+        "com.pepegar" %% "hammock-core" % V.hammock,
+        "com.pepegar" %% "hammock-circe" % V.hammock,
+        "com.pepegar" %% "hammock-asynchttpclient" % V.hammock,
+        "com.beachape" %% "enumeratum" % V.enumeratum,
+        "com.beachape" %% "enumeratum-circe" % V.enumeratum,
+        "com.julianpeeters" %% "avrohugger-core" % V.avroHugger,
+        %%("specs2-core", V.specs2) % Test,
         %%("specs2-scalacheck", V.specs2) % Test
       )
     )
@@ -152,7 +154,7 @@ object ProjectPlugin extends AutoPlugin {
       "docs/tut".asRunnableItem
     ),
     addCompilerPlugin("org.augustjune" %% "context-applied" % V.contextApplied),
-    addCompilerPlugin("org.typelevel"  %% "kind-projector"  % V.kindProjector cross CrossVersion.full)
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % V.kindProjector cross CrossVersion.full)
   )
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -14,71 +14,11 @@ import tut.TutPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
+  import autoImport._
+
   override def requires: Plugins = OrgPoliciesPlugin
 
   override def trigger: PluginTrigger = allRequirements
-
-  object autoImport {
-
-    val V = new {
-      val cats           = "2.1.0"
-      val contextApplied = "0.1.2"
-      val enumeratum     = "1.5.15"
-      val hammock        = "0.10.0"
-      val kindProjector  = "0.11.0"
-      val scala          = "2.12.10"
-      val specs2         = "4.8.3"
-      val avroHugger     = "1.0.0-RC22"
-      val pureconfig     = "0.12.2"
-    }
-
-    val clientSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        %%("cats-core", V.cats),
-        %%("pureconfig", V.pureconfig),
-        "com.github.pureconfig"           %% "pureconfig-cats-effect" % V.pureconfig,
-        "com.pepegar"                     %% "hammock-core" % V.hammock,
-        "com.pepegar"                     %% "hammock-circe" % V.hammock,
-        "com.pepegar"                     %% "hammock-asynchttpclient" % V.hammock,
-        "com.beachape"                    %% "enumeratum" % V.enumeratum,
-        "com.beachape"                    %% "enumeratum-circe" % V.enumeratum,
-        "com.julianpeeters"               %% "avrohugger-core" % V.avroHugger,
-        %%("specs2-core", V.specs2)       % Test,
-        %%("specs2-scalacheck", V.specs2) % Test
-      )
-    )
-
-    // Tut Settings
-    val tutSettings: Seq[Def.Setting[_]] = Seq(
-      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings", "-Ywarn-unused-import", "-Xlint").contains),
-      scalacOptions in Tut += "-language:postfixOps"
-    )
-
-    val micrositeSettings: Seq[Def.Setting[_]] = Seq(
-      micrositeName := "sbt-compendium",
-      micrositeDescription := "Schema transformations",
-      micrositeBaseUrl := "/sbt-compendium",
-      micrositeGithubOwner := "higherkindness",
-      micrositeGithubRepo := "sbt-compendium",
-      micrositeHighlightTheme := "tomorrow",
-      includeFilter in Jekyll := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md",
-      micrositePushSiteWith := GitHub4s,
-      micrositeExtraMdFiles := Map(
-        file("README.md") -> ExtraMdFileConfig(
-          "index.md",
-          "home",
-          Map("title" -> "Home", "section" -> "home", "position" -> "0")
-        ),
-        file("CHANGELOG.md") -> ExtraMdFileConfig(
-          "changelog.md",
-          "home",
-          Map("title" -> "changelog", "section" -> "changelog", "position" -> "99")
-        )
-      )
-    )
-  }
-
-  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     name := "sbt-compendium",
@@ -156,5 +96,71 @@ object ProjectPlugin extends AutoPlugin {
     addCompilerPlugin("org.augustjune" %% "context-applied" % V.contextApplied),
     addCompilerPlugin("org.typelevel"  %% "kind-projector"  % V.kindProjector cross CrossVersion.full)
   )
+
+  object autoImport {
+
+    val V = new {
+      val cats           = "2.1.0"
+      val contextApplied = "0.1.2"
+      val enumeratum     = "1.5.15"
+      val hammock        = "0.10.0"
+      val kindProjector  = "0.11.0"
+      val scala          = "2.12.10"
+      val specs2         = "4.8.3"
+      val avroHugger     = "1.0.0-RC22"
+      val pureconfig     = "0.12.2"
+      val skeuomorph     = "0.0.20"
+      val droste         = "0.8.0"
+      val scalameta      = "4.3.0"
+    }
+
+    val clientSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        %%("cats-core", V.cats),
+        %%("pureconfig", V.pureconfig),
+        "com.github.pureconfig" %% "pureconfig-cats-effect"  % V.pureconfig,
+        "com.pepegar"           %% "hammock-core"            % V.hammock,
+        "com.pepegar"           %% "hammock-circe"           % V.hammock,
+        "com.pepegar"           %% "hammock-asynchttpclient" % V.hammock,
+        "com.beachape"          %% "enumeratum"              % V.enumeratum,
+        "com.beachape"          %% "enumeratum-circe"        % V.enumeratum,
+        "com.julianpeeters"     %% "avrohugger-core"         % V.avroHugger,
+        "io.higherkindness"     %% "skeuomorph"              % V.skeuomorph,
+        "io.higherkindness"     %% "droste-core"             % V.droste,
+        %%("scalameta", V.scalameta),
+        %%("specs2-core", V.specs2)       % Test,
+        %%("specs2-scalacheck", V.specs2) % Test
+      )
+    )
+
+    // Tut Settings
+    val tutSettings: Seq[Def.Setting[_]] = Seq(
+      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings", "-Ywarn-unused-import", "-Xlint").contains),
+      scalacOptions in Tut += "-language:postfixOps"
+    )
+
+    val micrositeSettings: Seq[Def.Setting[_]] = Seq(
+      micrositeName := "sbt-compendium",
+      micrositeDescription := "Schema transformations",
+      micrositeBaseUrl := "/sbt-compendium",
+      micrositeGithubOwner := "higherkindness",
+      micrositeGithubRepo := "sbt-compendium",
+      micrositeHighlightTheme := "tomorrow",
+      includeFilter in Jekyll := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md",
+      micrositePushSiteWith := GitHub4s,
+      micrositeExtraMdFiles := Map(
+        file("README.md") -> ExtraMdFileConfig(
+          "index.md",
+          "home",
+          Map("title" -> "Home", "section" -> "home", "position" -> "0")
+        ),
+        file("CHANGELOG.md") -> ExtraMdFileConfig(
+          "changelog.md",
+          "home",
+          Map("title" -> "changelog", "section" -> "changelog", "position" -> "99")
+        )
+      )
+    )
+  }
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -21,29 +21,29 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     val V = new {
-      val cats = "2.1.0"
+      val cats           = "2.1.0"
       val contextApplied = "0.1.2"
-      val enumeratum = "1.5.15"
-      val hammock = "0.10.0"
-      val kindProjector = "0.11.0"
-      val scala = "2.12.10"
-      val specs2 = "4.8.3"
-      val avroHugger = "1.0.0-RC22"
-      val pureconfig = "0.12.2"
+      val enumeratum     = "1.5.15"
+      val hammock        = "0.10.0"
+      val kindProjector  = "0.11.0"
+      val scala          = "2.12.10"
+      val specs2         = "4.8.3"
+      val avroHugger     = "1.0.0-RC22"
+      val pureconfig     = "0.12.2"
     }
 
     val clientSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("cats-core", V.cats),
         %%("pureconfig", V.pureconfig),
-        "com.github.pureconfig" %% "pureconfig-cats-effect" % V.pureconfig,
-        "com.pepegar" %% "hammock-core" % V.hammock,
-        "com.pepegar" %% "hammock-circe" % V.hammock,
-        "com.pepegar" %% "hammock-asynchttpclient" % V.hammock,
-        "com.beachape" %% "enumeratum" % V.enumeratum,
-        "com.beachape" %% "enumeratum-circe" % V.enumeratum,
-        "com.julianpeeters" %% "avrohugger-core" % V.avroHugger,
-        %%("specs2-core", V.specs2) % Test,
+        "com.github.pureconfig"           %% "pureconfig-cats-effect" % V.pureconfig,
+        "com.pepegar"                     %% "hammock-core" % V.hammock,
+        "com.pepegar"                     %% "hammock-circe" % V.hammock,
+        "com.pepegar"                     %% "hammock-asynchttpclient" % V.hammock,
+        "com.beachape"                    %% "enumeratum" % V.enumeratum,
+        "com.beachape"                    %% "enumeratum-circe" % V.enumeratum,
+        "com.julianpeeters"               %% "avrohugger-core" % V.avroHugger,
+        %%("specs2-core", V.specs2)       % Test,
         %%("specs2-scalacheck", V.specs2) % Test
       )
     )
@@ -154,7 +154,7 @@ object ProjectPlugin extends AutoPlugin {
       "docs/tut".asRunnableItem
     ),
     addCompilerPlugin("org.augustjune" %% "context-applied" % V.contextApplied),
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % V.kindProjector cross CrossVersion.full)
+    addCompilerPlugin("org.typelevel"  %% "kind-projector"  % V.kindProjector cross CrossVersion.full)
   )
 
 }


### PR DESCRIPTION
This PR adds the missing models from `compendium-common` to the `sbt-compendium-client` module.